### PR TITLE
Add custom color settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,164 @@ dist
 .yarn/install-state.gz
 .pnp.*
 src/3rd
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/javascript/main.js
+++ b/javascript/main.js
@@ -70,7 +70,10 @@ enableCheckerInit = function () {
     if (color_enable !== null) {
       return;
     }
-    if (isDarkColor(document.body.style.backgroundColor)) {
+    if (opts?.enable_checker_custom_color) {
+      color_enable = opts.enable_checker_custom_color_enable;
+      color_disable = opts.enable_checker_custom_color_disable;
+    } else if (isDarkColor(document.body.style.backgroundColor)) {
       color_enable = "#237366";
       color_disable = "#5a5757";
     } else {

--- a/scripts/enable_checker.py
+++ b/scripts/enable_checker.py
@@ -1,0 +1,38 @@
+from modules import script_callbacks, shared
+
+try:
+    from modules import ui_components
+
+    FormColorPicker = ui_components.FormColorPicker
+except (ImportError, AttributeError):
+    # for compatibility with old webui
+    FormColorPicker = None
+
+
+def on_ui_settings():
+    section = ("enable_checker", "Enable Checker")
+    shared.opts.add_option(
+        "enable_checker_custom_color",
+        shared.OptionInfo(False, "Use custom colors", section=section),
+    )
+    shared.opts.add_option(
+        "enable_checker_custom_color_enable",
+        shared.OptionInfo(
+            "#a0d8ef",
+            "Custom color of enabled scripts",
+            FormColorPicker,
+            section=section,
+        ),
+    )
+    shared.opts.add_option(
+        "enable_checker_custom_color_disable",
+        shared.OptionInfo(
+            "#aeaeae",
+            "Custom color of disabled scripts",
+            FormColorPicker,
+            section=section,
+        ),
+    )
+
+
+script_callbacks.on_ui_settings(on_ui_settings)


### PR DESCRIPTION
Close #9

Add custom color settings.
カスタムカラーの設定を追加します。

Enabling "Use custom colors" will override the color settings to "Custom color of enabled/disabled scripts".
「Use custom colors」を有効にすると、色設定が「Custom color of enabled/disabled scripts」で上書きされます。