### PR TITLE
Add check for InputAccordion

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -259,14 +259,27 @@ var enableCheckerInit = function () {
   function operate_component_in_script_container(component) {
     operate_dropdown(component);
     operate_value_input(component);
+
+    const header = get_component_header(component);
+    if (!header) {
+      return;
+    }
+
+    // check modules.ui_components.InputAccordion
+    let is_active = false;
+    const checkbox = header.querySelector("input[type=checkbox]");
+    if (checkbox) {
+      is_active = checkbox.checked;
+      change_bg(header, is_active);
+      return;
+    }
+
     const enable_span = get_enable_span(component);
     if (!enable_span) {
       return;
     }
 
-    const header = get_component_header(component);
     const controlnet_parts = component.querySelector("#controlnet");
-    let is_active = false;
     if (controlnet_parts) {
       is_active = operate_controlnet_component(controlnet_parts);
 


### PR DESCRIPTION
Add check for [modules.ui_components.InputAccordion](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/feee37d75f1b168768014e4634dcb156ee649c05/modules/ui_components.py#L88) in extensions.

For example, InputAccordion is used in [multidiffusion-upscaler-for-automatic1111](https://github.com/pkuliyi2015/multidiffusion-upscaler-for-automatic1111).  
![image](https://github.com/shirayu/sd-webui-enable-checker/assets/42905588/109669d5-9e58-4e3f-baa2-966902a7ed1c)
